### PR TITLE
Add exports and exact versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,18 @@
   "private": false,
   "version": "0.9.0",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/ilw-hero.js"
+    }
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build --config vite.build.config.js --emptyOutDir",
     "preview": "vite preview"
   },
   "dependencies": {
-    "lit": "^3.1.2"
+    "lit": "3.1.3"
   },
   "devDependencies": {
     "vite": "^5.2.0"


### PR DESCRIPTION
Added exports to package.json, and made the lit dependency use exact versioning. These are both necessary for it to work consistently with bundling in the toolkit.